### PR TITLE
localhost以外のIPアドレスをListenしたい場合は明示的に指定するように

### DIFF
--- a/unityproject/Assets/ClusterLab/Scripts/Infrastructure/Server/AgentServer.cs
+++ b/unityproject/Assets/ClusterLab/Scripts/Infrastructure/Server/AgentServer.cs
@@ -30,12 +30,14 @@ namespace ClusterLab.Infrastructure.Server
 
         readonly string domain;
         readonly int port;
+        readonly List<string> localIPs;
 
         readonly IAgentDriver agentDriver;
         List<AgentServerHandler> handlers;
 
-        public AgentServer(IAgentDriver agentDriver, string domain = "localhost", int port = 8080)
+        public AgentServer(IAgentDriver agentDriver, List<string> localIPs = null, string domain = "localhost", int port = 8080)
         {
+            this.localIPs = localIPs ?? GetLocalIPs().ToList();
             this.domain = domain;
             this.port = port;
             this.agentDriver = agentDriver;
@@ -57,14 +59,10 @@ namespace ClusterLab.Infrastructure.Server
                 .Select(address => address.Address.ToString());
         }
 
-        public void StartServer(List<string> localIPs = null)
+        public void StartServer()
         {
             listener = new HttpListener();
             listener.Prefixes.Add("http://" + domain + ":" + port + "/");
-            if (localIPs == null)
-            {
-                localIPs = GetLocalIPs().ToList();
-            }
             localIPs.ForEach(ip => listener.Prefixes.Add("http://" + ip + ":" + port + "/"));
             localIPs.ForEach(ip => Debug.Log(ip));
             listener.AuthenticationSchemes = AuthenticationSchemes.Anonymous;

--- a/unityproject/Assets/ClusterLab/Scripts/Infrastructure/Server/AgentServer.cs
+++ b/unityproject/Assets/ClusterLab/Scripts/Infrastructure/Server/AgentServer.cs
@@ -57,11 +57,14 @@ namespace ClusterLab.Infrastructure.Server
                 .Select(address => address.Address.ToString());
         }
 
-        public void StartServer()
+        public void StartServer(List<string> localIPs = null)
         {
             listener = new HttpListener();
             listener.Prefixes.Add("http://" + domain + ":" + port + "/");
-            var localIPs = GetLocalIPs().ToList();
+            if (localIPs == null)
+            {
+                localIPs = GetLocalIPs().ToList();
+            }
             localIPs.ForEach(ip => listener.Prefixes.Add("http://" + ip + ":" + port + "/"));
             localIPs.ForEach(ip => Debug.Log(ip));
             listener.AuthenticationSchemes = AuthenticationSchemes.Anonymous;

--- a/unityproject/Assets/ClusterLab/Scripts/UseCase/SearchAgent.cs
+++ b/unityproject/Assets/ClusterLab/Scripts/UseCase/SearchAgent.cs
@@ -44,8 +44,8 @@ namespace ClusterLab.UseCase
             sceneRenderer = new SceneRendererImpl(tileCameraRenderer);
             agentDriver = new AgentDriverImpl(sceneRenderer, nodeRenderer);
 
-            agentServer = new AgentServer(agentDriver);
-            agentServer.StartServer(listeningIPs);
+            agentServer = new AgentServer(agentDriver, listeningIPs);
+            agentServer.StartServer();
         }
 
         void OnDestroy()

--- a/unityproject/Assets/ClusterLab/Scripts/UseCase/SearchAgent.cs
+++ b/unityproject/Assets/ClusterLab/Scripts/UseCase/SearchAgent.cs
@@ -1,4 +1,5 @@
-﻿using ClusterLab.Infrastructure.Agent;
+﻿using System.Collections.Generic;
+using ClusterLab.Infrastructure.Agent;
 using ClusterLab.Infrastructure.Server;
 using ClusterLab.UseCase.Render;
 using UnityEngine;
@@ -19,6 +20,7 @@ namespace ClusterLab.UseCase
         [SerializeField] TextAsset assetBundleJsonTextAsset;
         [SerializeField] GameObject TileRendererGameObject;
         [SerializeField] GameObject NodeRendererGameObject;
+        [SerializeField] List<string> listeningIPs;
 
         IAgentDriver agentDriver;
         ISceneRenderer sceneRenderer;
@@ -43,7 +45,7 @@ namespace ClusterLab.UseCase
             agentDriver = new AgentDriverImpl(sceneRenderer, nodeRenderer);
 
             agentServer = new AgentServer(agentDriver);
-            agentServer.StartServer();
+            agentServer.StartServer(listeningIPs);
         }
 
         void OnDestroy()


### PR DESCRIPTION
Unity側の実行時、自身のローカルIPアドレス以外の接続先（おそらく仮想ネットワークアダプタ等）をListenしようとしてエラーが発生するケースがありました
localhost以外をListenする必要がある場合はコンポーネントのプロパティとして明示的に接続先を指定する方式になると便利そうに思います